### PR TITLE
feat: add TRAINING_STATUS_ADMIN_PORTAL_AUD output for worker integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,29 @@ An optional Cloudflare Access application that integrates with the **Training Co
   - Integration with Competition App policy for conditional access
   - Multi-path domain configuration (`/admin`, `/api/*`, `/admin*`, `/init-db`)
 
+#### Worker Configuration
+
+When deploying this component, Terraform will output the `TRAINING_STATUS_ADMIN_PORTAL_AUD` value, which is the unique Application Audience (AUD) Tag required for the Training Compliance Gateway worker authentication.
+
+**Setup Steps:**
+
+1. **Deploy this Terraform configuration** - The AUD value will be available in outputs
+2. **Configure the worker secret** using the AUD value:
+   ```bash
+   # Get the AUD value from Terraform output
+   terraform output TRAINING_STATUS_ADMIN_PORTAL_AUD
+   
+   # Set the worker secret (replace with your actual AUD value)
+   echo "8a47b4391d556b42e9c7b0bba0d3896c7579bd0ffad37453b608bc489ed070fc" | wrangler secret put ACCESS_APP_AUD --name cloudflare-access-training-evaluator
+   ```
+
+3. **Deploy/update the worker** - After setting the secret, deploy or redeploy your worker:
+   ```bash
+   wrangler deploy --name cloudflare-access-training-evaluator
+   ```
+   
+   > **Note**: The worker needs to be redeployed after setting the `ACCESS_APP_AUD` secret to ensure the new configuration is loaded properly.
+
 > **⚠️ Important Notes:**
 > - The Training Status Admin Portal app and policy will only function if the Training Compliance Gateway is deployed and running
 > - If you haven't deployed the Training Compliance Gateway, you must comment out the `require_external_evaluation` settings in the Competition App Policy (located in `modules/cloudflare/cloudflare-app-policies.tf`), otherwise the Competition App won't work or appear in the App Launcher

--- a/README.md
+++ b/README.md
@@ -677,4 +677,5 @@ This project is provided as-is for educational and demonstration purposes. Pleas
 | <a name="output_GCP_COMPUTE_INSTANCES"></a> [GCP\_COMPUTE\_INSTANCES](#output\_GCP\_COMPUTE\_INSTANCES) | GCP instance details |
 | <a name="output_MY_IP"></a> [MY\_IP](#output\_MY\_IP) | This is your Public IP |
 | <a name="output_SSH_FOR_INFRASTRUCTURE_ACCESS"></a> [SSH\_FOR\_INFRASTRUCTURE\_ACCESS](#output\_SSH\_FOR\_INFRASTRUCTURE\_ACCESS) | SSH with Access for Infrastructure command |
+| <a name="output_TRAINING_STATUS_ADMIN_PORTAL_AUD"></a> [TRAINING\_STATUS\_ADMIN\_PORTAL\_AUD](#output\_TRAINING\_STATUS\_ADMIN\_PORTAL\_AUD) | Application Audience (AUD) Tag for the Training Status Admin Portal - use this value for ACCESS\_APP\_AUD in your worker |
 <!-- END_TF_DOCS -->

--- a/modules/cloudflare/outputs.tf
+++ b/modules/cloudflare/outputs.tf
@@ -124,3 +124,8 @@ output "gateway_ca_certificate" {
   value       = local.gateway_ca_certificate.result.public_key
   sensitive   = true
 }
+
+output "training_status_admin_portal_aud" {
+  description = "Application Audience (AUD) Tag for the Training Status Admin Portal"
+  value       = cloudflare_zero_trust_access_application.training_status_admin_portal.aud
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -99,3 +99,9 @@ output "SSH_FOR_INFRASTRUCTURE_ACCESS" {
     username => "ssh ${username}@${google_compute_instance.gcp_cloudflared_vm_instance.network_interface[0].network_ip}"
   }
 }
+
+# Training Status Admin Portal Application Audience (AUD) Tag
+output "TRAINING_STATUS_ADMIN_PORTAL_AUD" {
+  description = "Application Audience (AUD) Tag for the Training Status Admin Portal - use this value for ACCESS_APP_AUD in your worker"
+  value       = module.cloudflare.training_status_admin_portal_aud
+}


### PR DESCRIPTION
## Summary
- Add `TRAINING_STATUS_ADMIN_PORTAL_AUD` output to expose the Application Audience (AUD) Tag for the Training Status Admin Portal
- Update README.md with comprehensive worker configuration documentation
- Include step-by-step instructions for configuring the `ACCESS_APP_AUD` secret in the Training Compliance Gateway worker

## Changes
- **outputs.tf**: Added `TRAINING_STATUS_ADMIN_PORTAL_AUD` output that references the module output
- **modules/cloudflare/outputs.tf**: Added `training_status_admin_portal_aud` output exposing the AUD value
- **README.md**: Enhanced Training Status Admin Portal documentation with:
  - Worker configuration section
  - Step-by-step setup instructions
  - Command-line examples for setting worker secrets
  - Note about worker redeployment requirement

## Benefits
- Eliminates manual copy-paste of AUD values from Cloudflare dashboard
- Provides automated way to configure worker secrets via Terraform outputs
- Improves developer experience with clear setup instructions
- Ensures proper integration between Terraform-managed Access apps and Workers

## Test plan
- [x] Verify `terraform output TRAINING_STATUS_ADMIN_PORTAL_AUD` displays correct AUD value
- [x] Test that the output can be used with wrangler secret commands
- [x] Confirm documentation accuracy and completeness