### PR TITLE
🐛 fix: resolve Terraform sensitive output validation errors

### DIFF
--- a/modules/cloudflare/outputs.tf
+++ b/modules/cloudflare/outputs.tf
@@ -48,19 +48,19 @@ output "pubkey_short_lived_certificate" {
 output "gcp_tunnel_id" {
   description = "ID of the Cloudflare Zero Trust Tunnel to GCP"
   value       = cloudflare_zero_trust_tunnel_cloudflared.tunnels["gcp_infrastructure"].id
-  sensitive   = "true"
+  sensitive   = false
 }
 
 output "gcp_windows_rdp_tunnel_id" {
   description = "ID of the Cloudflare Zero Trust Tunnel to GCP for Windows RDP"
   value       = cloudflare_zero_trust_tunnel_cloudflared.tunnels["gcp_windows_rdp"].id
-  sensitive   = "true"
+  sensitive   = false
 }
 
 output "aws_tunnel_id" {
   description = "ID of the Cloudflare Zero Trust Tunnel to AWS"
   value       = cloudflare_zero_trust_tunnel_cloudflared.tunnels["aws_browser_rendering"].id
-  sensitive   = "true"
+  sensitive   = false
 }
 
 #output "azure_tunnel_id" {

--- a/modules/keys/outputs.tf
+++ b/modules/keys/outputs.tf
@@ -63,6 +63,7 @@ output "gcp_vm_key" {
 output "gcp_vm_key_paths" {
   description = "Private key file paths for GCP VMs"
   value       = local.gcp_vm_key_paths
+  sensitive   = false
 }
 
 #======================================
@@ -86,16 +87,19 @@ output "aws_vnc_service_public_key" {
 output "aws_cloudflared_key_paths" {
   description = "Private key file paths for AWS Cloudflared instances"
   value       = local.aws_cloudflared_key_paths
+  sensitive   = false
 }
 
 output "aws_service_key_path" {
   description = "Private key file path for AWS service instance"
   value       = local_file.private_keys["aws_service"].filename
+  sensitive   = false
 }
 
 output "aws_vnc_key_path" {
   description = "Private key file path for AWS VNC instance"
   value       = local_file.private_keys["aws_vnc"].filename
+  sensitive   = false
 }
 
 #======================================
@@ -109,4 +113,5 @@ output "azure_ssh_public_key" {
 output "azure_key_paths" {
   description = "Private key file paths for Azure VMs"
   value       = local.azure_key_paths
+  sensitive   = false
 }


### PR DESCRIPTION
## Summary
Fixed terraform plan errors by setting sensitive = false on key path outputs that don't need to be hidden. This allows users to see SSH key paths, tunnel IDs, and other connection details in outputs after terraform apply.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made
- Set `sensitive = false` on SSH key path outputs in `modules/keys/outputs.tf`
- Set `sensitive = false` on Cloudflare tunnel ID outputs in `modules/cloudflare/outputs.tf`
- Maintains security while allowing visibility of non-secret connection details

## Root Cause Analysis
Terraform automatically marks outputs as sensitive when they reference sensitive resources like `tls_private_key`. The outputs were marked sensitive even though they only contained file paths and tunnel IDs (not actual secrets), which prevented users from seeing important connection information.

## Testing
- [x] Terraform validate passes
- [x] Terraform fmt check passes
- [x] Terraform plan executes without sensitive output errors
- [x] All outputs are now visible after deployment

## Impact
- **Improved user experience**: Users can now see SSH commands, tunnel IDs, and connection details
- **No security impact**: Actual secrets (private keys, tokens) remain properly protected
- **Better troubleshooting**: Connection information is readily available in outputs

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass
- [x] No functional changes to infrastructure