### PR TITLE
🔧 fix: resolve automated release workflow GitHub action reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: 🚀 Create GitHub Release
         if: steps.version.outputs.create_release == 'true'
-        uses: ncipollo/action-gh-release@v2
+        uses: ncipollo/release-action@v1
         with:
           tag: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}
@@ -84,6 +84,7 @@ jobs:
           draft: false
           prerelease: false
           generateReleaseNotes: false
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ✅ Release Summary
         if: steps.version.outputs.create_release == 'true'


### PR DESCRIPTION
## Summary

- Fix incorrect GitHub action reference causing automated release workflow failures
- Replace `ncipollo/action-gh-release@v2` with `ncipollo/release-action@v1`
- Add explicit `GITHUB_TOKEN` parameter for authentication
- Resolves the failure preventing automated v2.3.0 release creation

## Problem

The automated release workflow was failing with error:
```
Unable to resolve action ncipollo/action-gh-release, repository not found
```

## Solution

- Updated to use the correct action reference: `ncipollo/release-action@v1`
- Added explicit `token: ${{ secrets.GITHUB_TOKEN }}` parameter
- This should allow the workflow to properly create releases when CHANGELOG.md is updated

## Test Plan

- [x] Action reference updated to correct repository
- [x] Authentication token added for GitHub API access
- [x] Workflow syntax validated
- [ ] Automated release creation will be tested on next CHANGELOG.md update

🤖 Generated with [Claude Code](https://claude.com/claude-code)