### PR TITLE
🔧 fix: add manual trigger to release workflow and trigger v2.3.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths: ['CHANGELOG.md']
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
 ## [2.3.0] - 2025-09-29
 
 ### Added


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to enable manual release workflow runs
- Minor formatting adjustment to CHANGELOG.md to trigger automated v2.3.0 release
- Ensures v2.3.0 release gets created after previous GitHub action reference fix

## Problem

The v2.3.0 release was not created automatically when CHANGELOG.md was initially updated due to the GitHub action reference issue. Now that the action reference is fixed, we need to trigger the release workflow again.

## Changes

1. **Release Workflow Enhancement**: Added `workflow_dispatch` trigger for manual workflow runs
2. **Trigger v2.3.0 Release**: Minor formatting change to CHANGELOG.md that will cause the release workflow to run and create the missing v2.3.0 release

## Test Plan

- [x] workflow_dispatch trigger added to release.yml
- [x] CHANGELOG.md modification will trigger release workflow on merge
- [ ] v2.3.0 release will be created automatically upon merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)