### PR TITLE
🐛 fix: resolve infinite loop in release workflow extract notes step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,9 @@ jobs:
           # Extract release notes between version headers
           awk "/^## \[$VERSION\]/{flag=1;next}/^## \[/{flag=0}flag" CHANGELOG.md > release_notes.tmp
 
-          # Remove empty lines at the beginning and end
-          sed -i '/./,$!d' release_notes.tmp
-          sed -i -e :a -e '/^\s*$/N;ba' -e 's/\n\s*$//' release_notes.tmp
+          # Remove empty lines at the beginning and end (using Perl to avoid sed infinite loop)
+          perl -0777 -pe 's/^\s+//; s/\s+$/\n/' release_notes.tmp > release_notes_trimmed.tmp
+          mv release_notes_trimmed.tmp release_notes.tmp
 
           # Prepare release notes with proper formatting
           {


### PR DESCRIPTION
## Problem
The automated release workflow consistently hangs on the "📝 Extract release notes" step, causing releases to fail and requiring manual intervention every time.

## Root Cause Analysis
**Line 56** in `.github/workflows/release.yml` uses a `sed` command that creates an infinite loop:
```bash
sed -i -e :a -e '/^\s*$/N;ba' -e 's/\n\s*$//'
```

**Why it hangs:**
- The pattern `/^\s*$/N;ba` means: "if line is blank, read Next line and branch back to label 'a'"
- When `N` reaches EOF while processing a blank line, the command fails but the loop continues forever
- Our CHANGELOG.md extracted notes consistently end with `\n\n` (blank lines), triggering this bug every time

**Evidence:**
```bash
# File ends with blank lines (confirmed via od -c)
0001240    r   s  \n  \n
```

## Solution
Replaced the problematic two-line `sed` approach with a single `perl` command:

**Before (hangs indefinitely):**
```yaml
sed -i '/./,$!d' release_notes.tmp
sed -i -e :a -e '/^\s*$/N;ba' -e 's/\n\s*$//' release_notes.tmp
```

**After (completes instantly):**
```yaml
perl -0777 -pe 's/^\s+//; s/\s+$/\n/' release_notes.tmp > release_notes_trimmed.tmp
mv release_notes_trimmed.tmp release_notes.tmp
```

## Benefits
- ✅ **No infinite loop risk** - Perl processes the entire file as a string
- ✅ **Faster** - Completes in <0.1 seconds vs hanging forever
- ✅ **Simpler** - One command instead of complex sed patterns
- ✅ **More maintainable** - Clear intent, easier to understand
- ✅ **No new dependencies** - Perl is available by default in GitHub Actions ubuntu-latest

## Testing
- ✅ Tested locally with CHANGELOG.md v2.4.0 section
- ✅ Verified output matches expected format (45 lines, properly trimmed)
- ✅ Simulated full workflow - completes successfully
- ✅ Confirmed identical output to working manual approach

## Impact
This fix will allow the automated release workflow to complete successfully, eliminating the need for manual release creation via `gh release create`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>