### PR TITLE
✨ feat: add configurable AWS spot instance toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,7 @@ This project is provided as-is for educational and demonstration purposes. Pleas
 | <a name="input_aws_private_cidr"></a> [aws\_private\_cidr](#input\_aws\_private\_cidr) | AWS private subnet, subnet for VMs in AWS | `string` | n/a | yes |
 | <a name="input_aws_public_cidr"></a> [aws\_public\_cidr](#input\_aws\_public\_cidr) | AWS public subnet | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-central-1"` | no |
+| <a name="input_aws_use_spot_instances"></a> [aws\_use\_spot\_instances](#input\_aws\_use\_spot\_instances) | Whether to use spot instances for AWS EC2 (false = on-demand for reliability, true = spot for cost savings) | `bool` | `false` | no |
 | <a name="input_aws_users"></a> [aws\_users](#input\_aws\_users) | List of all the AWS users | `list(string)` | n/a | yes |
 | <a name="input_aws_vm_default_user"></a> [aws\_vm\_default\_user](#input\_aws\_vm\_default\_user) | default user for AWS VM | `string` | n/a | yes |
 | <a name="input_aws_vnc_password"></a> [aws\_vnc\_password](#input\_aws\_vnc\_password) | VNC password for AWS VM | `string` | n/a | yes |

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -46,6 +46,7 @@ aws_ec2_vnc_instance_type      = "t3.micro"  # VNC instance (set to t3.small for
 
 aws_cloudflared_count          = 1
 aws_ec2_cloudflared_name       = "cloudflared-replica-aws"
+aws_use_spot_instances         = false # Set to true for cost savings, false for reliability
 
 aws_users                      = ["matthieu", "jose", "bob", "andy"]
 aws_vm_default_user            = "ubuntu"

--- a/variables.tf
+++ b/variables.tf
@@ -157,6 +157,12 @@ variable "aws_cloudflared_count" {
   default     = 1
 }
 
+variable "aws_use_spot_instances" {
+  description = "Whether to use spot instances for AWS EC2 (false = on-demand for reliability, true = spot for cost savings)"
+  type        = bool
+  default     = false
+}
+
 # AWS Instance Names
 variable "aws_ec2_browser_ssh_name" {
   description = "Name of the EC2 instance browser rendered SSH"

--- a/vm-aws-instance.tf
+++ b/vm-aws-instance.tf
@@ -188,15 +188,15 @@ locals {
     Service     = "cloudflare-zero-trust-demo"
   }
 
-  # Spot instance configuration
-  aws_spot_instance_options = {
+  # Spot instance configuration (conditional based on variable)
+  aws_spot_instance_options = var.aws_use_spot_instances ? {
     market_type = "spot"
     spot_options = {
-      max_price                      = "0.010"
+      # No max_price specified - defaults to on-demand price
       spot_instance_type             = "one-time"
       instance_interruption_behavior = "terminate"
     }
-  }
+  } : null
 }
 
 #==========================================================
@@ -210,12 +210,14 @@ resource "aws_instance" "aws_vm_cloudflared" {
   vpc_security_group_ids = [aws_security_group.aws_sg_cloudflared.id]
   key_name               = aws_key_pair.aws_ec2_cloudflared_key_pair[count.index].key_name
 
-  instance_market_options {
-    market_type = local.aws_spot_instance_options.market_type
-    spot_options {
-      max_price                      = local.aws_spot_instance_options.spot_options.max_price
-      spot_instance_type             = local.aws_spot_instance_options.spot_options.spot_instance_type
-      instance_interruption_behavior = local.aws_spot_instance_options.spot_options.instance_interruption_behavior
+  dynamic "instance_market_options" {
+    for_each = local.aws_spot_instance_options != null ? [1] : []
+    content {
+      market_type = local.aws_spot_instance_options.market_type
+      spot_options {
+        spot_instance_type             = local.aws_spot_instance_options.spot_options.spot_instance_type
+        instance_interruption_behavior = local.aws_spot_instance_options.spot_options.instance_interruption_behavior
+      }
     }
   }
 
@@ -247,12 +249,14 @@ resource "aws_instance" "aws_vm_service" {
   vpc_security_group_ids = [aws_security_group.aws_sg_ssh.id]
   key_name               = aws_key_pair.aws_ec2_service_key_pair.key_name
 
-  instance_market_options {
-    market_type = local.aws_spot_instance_options.market_type
-    spot_options {
-      max_price                      = local.aws_spot_instance_options.spot_options.max_price
-      spot_instance_type             = local.aws_spot_instance_options.spot_options.spot_instance_type
-      instance_interruption_behavior = local.aws_spot_instance_options.spot_options.instance_interruption_behavior
+  dynamic "instance_market_options" {
+    for_each = local.aws_spot_instance_options != null ? [1] : []
+    content {
+      market_type = local.aws_spot_instance_options.market_type
+      spot_options {
+        spot_instance_type             = local.aws_spot_instance_options.spot_options.spot_instance_type
+        instance_interruption_behavior = local.aws_spot_instance_options.spot_options.instance_interruption_behavior
+      }
     }
   }
 
@@ -283,12 +287,14 @@ resource "aws_instance" "aws_vm_vnc" {
   vpc_security_group_ids = [aws_security_group.aws_sg_vnc.id]
   key_name               = aws_key_pair.aws_ec2_vnc_key_pair.key_name
 
-  instance_market_options {
-    market_type = local.aws_spot_instance_options.market_type
-    spot_options {
-      max_price                      = local.aws_spot_instance_options.spot_options.max_price
-      spot_instance_type             = local.aws_spot_instance_options.spot_options.spot_instance_type
-      instance_interruption_behavior = local.aws_spot_instance_options.spot_options.instance_interruption_behavior
+  dynamic "instance_market_options" {
+    for_each = local.aws_spot_instance_options != null ? [1] : []
+    content {
+      market_type = local.aws_spot_instance_options.market_type
+      spot_options {
+        spot_instance_type             = local.aws_spot_instance_options.spot_options.spot_instance_type
+        instance_interruption_behavior = local.aws_spot_instance_options.spot_options.instance_interruption_behavior
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Add configurable AWS spot instance toggle to resolve terraform timeout errors caused by spot capacity constraints.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Changes Made
- Added `aws_use_spot_instances` boolean variable with default `false` for on-demand reliability
- Implemented dynamic `instance_market_options` blocks across all AWS EC2 resources (cloudflared, service, VNC)
- Updated `terraform.tfvars.example` with configuration guidance and inline comments
- Removed hardcoded `max_price` from spot configuration (defaults to on-demand price)
- Applied conditional logic using ternary operator to enable/disable spot instances

## Problem Solved
Previously, all AWS EC2 instances used hardcoded spot instance configuration, leading to:
- `operation error EC2: RunInstances, request canceled, context canceled` timeout errors
- Deployment failures due to spot capacity unavailability in eu-central-1 region
- No option to use on-demand instances for guaranteed capacity

## Solution
Users can now toggle between:
- **On-demand instances** (`aws_use_spot_instances = false`): Guaranteed capacity, higher cost, demo reliability
- **Spot instances** (`aws_use_spot_instances = true`): Cost savings, potential capacity constraints

Default is on-demand for production/demo reliability, with easy opt-in to spot for cost optimization.

## Testing
- ✅ TFLint validation passed (root + all modules)
- ✅ Terraform formatting verified
- ✅ Terraform configuration validated
- ✅ Plan generated successfully with on-demand configuration

## Implementation Details
**variables.tf:160-164**
```hcl
variable "aws_use_spot_instances" {
  description = "Whether to use spot instances for AWS EC2 (false = on-demand for reliability, true = spot for cost savings)"
  type        = bool
  default     = false
}
```

**vm-aws-instance.tf:192-199**
```hcl
aws_spot_instance_options = var.aws_use_spot_instances ? {
  market_type = "spot"
  spot_options = {
    spot_instance_type             = "one-time"
    instance_interruption_behavior = "terminate"
  }
} : null
```

**vm-aws-instance.tf (all 3 instances)**
```hcl
dynamic "instance_market_options" {
  for_each = local.aws_spot_instance_options != null ? [1] : []
  content {
    market_type = local.aws_spot_instance_options.market_type
    spot_options {
      spot_instance_type             = local.aws_spot_instance_options.spot_options.spot_instance_type
      instance_interruption_behavior = local.aws_spot_instance_options.spot_options.instance_interruption_behavior
    }
  }
}
```

## Migration Notes
Users should update their `terraform.tfvars` to include:
```hcl
aws_use_spot_instances = false  # Or true for cost savings
```

Existing deployments will default to on-demand instances on next `terraform apply`.