### PR TITLE
🔖 chore: release v2.7.0 - configurable AWS spot instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0] - 2025-10-06
+
+### Added
+
+- **Configurable AWS Spot Instance Toggle**: Added `aws_use_spot_instances` variable to control spot vs on-demand instance usage
+  - New boolean variable with default `false` for on-demand reliability (variables.tf:160-164)
+  - Conditional `aws_spot_instance_options` using ternary operator for dynamic configuration
+  - Dynamic `instance_market_options` blocks across all AWS EC2 resources (cloudflared, service, VNC)
+  - Resolves timeout errors caused by spot capacity constraints in AWS regions
+  - Allows users to toggle between guaranteed capacity (on-demand) and cost savings (spot)
+  - Updated terraform.tfvars.example with configuration guidance
+
+### Changed
+
+- **AWS Spot Instance Configuration**: Removed hardcoded `max_price` from spot configuration
+  - Now defaults to on-demand price for better availability
+  - Applied conditional logic using dynamic blocks for cleaner infrastructure code
+  - Affects all three AWS EC2 instance types: cloudflared replicas, SSH service, and VNC desktop
+
 ## [2.6.0] - 2025-10-01
 
 ### Added


### PR DESCRIPTION
## Release v2.7.0

This release introduces configurable AWS spot instance toggle to resolve deployment reliability issues caused by spot capacity constraints.

### Summary of Changes

#### Added
- **`aws_use_spot_instances` Variable**: New boolean variable to control spot vs on-demand instance usage
  - Default: `false` for on-demand reliability (variables.tf:160-164)
  - Allows toggling between guaranteed capacity (on-demand) and cost savings (spot)
- **Dynamic Instance Configuration**: Conditional `aws_spot_instance_options` using ternary operator
  - Dynamic `instance_market_options` blocks across all AWS EC2 resources
  - Applied to cloudflared replicas, SSH service, and VNC desktop instances
- **Configuration Guidance**: Updated terraform.tfvars.example with inline documentation

#### Changed
- **Spot Configuration Optimization**: Removed hardcoded `max_price` from spot configuration
  - Now defaults to on-demand price for better availability
  - Applied conditional logic using dynamic blocks for cleaner infrastructure code

### Problem Solved

Resolves terraform timeout errors (`operation error EC2: RunInstances, request canceled, context canceled`) caused by spot capacity constraints in AWS regions, particularly in eu-central-1.

### Migration Notes

Users should update their `terraform.tfvars` to include:
```hcl
aws_use_spot_instances = false  # Or true for cost savings
```

Existing deployments will default to on-demand instances on next `terraform apply`.

### Version Information

- **Version**: 2.7.0
- **Release Date**: 2025-10-06
- **Type**: Minor release (new feature)
- **Breaking Changes**: None

---

**Merging this PR will automatically trigger the GitHub release workflow.**