### PR TITLE
📝 docs: add S3 backend prerequisite and Azure CLI install command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.2] - 2025-11-25
+
+### Added
+
+- **S3 Backend Documentation**: Added comprehensive section documenting the required S3 backend infrastructure
+  - Links to the [cloudflare-zero-trust-demo-backend](https://github.com/macharpe/cloudflare-zero-trust-demo-backend) repository
+  - Documents S3 bucket, DynamoDB table, and IAM policies requirements
+  - Provides step-by-step setup instructions for new deployments
+  - Added Table of Contents entry for the new section
+
+### Changed
+
+- **Azure CLI Installation**: Added macOS installation command (`brew install azure-cli`) to Required Tools section
+
 ## [2.9.1] - 2025-10-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A comprehensive, production-ready Terraform infrastructure that demonstrates Clo
 - [📊 Project Statistics](#-project-statistics)
 - [📚 Background Reading](#-background-reading)
 - [📋 Prerequisites](#-prerequisites)
+  - [S3 Backend Infrastructure (Required)](#s3-backend-infrastructure-required)
 - [🛠️ Step-by-Step Setup](#️-step-by-step-setup)
   - [1. Clone and Initialize](#1-clone-and-initialize)
   - [2. Configure Cloudflare API Token Permissions](#2-configure-cloudflare-api-token-permissions)
@@ -221,9 +222,27 @@ Before deploying this infrastructure, ensure you have the following accounts and
 
 - **Terraform** >= 1.12.0
 - **AWS CLI** configured with credentials
-- **Azure CLI** configured with subscription
+- **Azure CLI** configured with subscription (`brew install azure-cli` on macOS)
 - **Google Cloud SDK** with service account
 - **Git** for version control
+
+### S3 Backend Infrastructure (Required)
+
+This project uses an S3 backend with DynamoDB for Terraform state management. **You must deploy the backend infrastructure before cloning and initializing this repository.**
+
+**Backend Repository**: [cloudflare-zero-trust-demo-backend](https://github.com/macharpe/cloudflare-zero-trust-demo-backend)
+
+The backend infrastructure includes:
+- **S3 Bucket**: Stores Terraform state files with versioning and encryption
+- **DynamoDB Table**: Provides state locking to prevent concurrent modifications
+- **IAM Policies**: Secure access controls for state management
+
+**Setup Steps:**
+1. Clone the backend repository: `git clone https://github.com/macharpe/cloudflare-zero-trust-demo-backend`
+2. Follow the setup instructions in the backend repository README
+3. Deploy the S3 + DynamoDB infrastructure with `terraform apply`
+4. Note the S3 bucket name and DynamoDB table name from the outputs
+5. Return to this repository and configure `backend.conf` with those values (see [Step 6](#6-configure-backend-first-time-setup))
 
 ## 🛠️ Step-by-Step Setup
 


### PR DESCRIPTION
## Summary

- Add comprehensive S3 Backend Infrastructure section under Prerequisites
- Link to cloudflare-zero-trust-demo-backend repository for state management
- Add macOS installation command for Azure CLI (`brew install azure-cli`)

## Type of Change

- [x] Documentation update

## Changes Made

- **README.md**:
  - Added new "S3 Backend Infrastructure (Required)" section under Prerequisites
  - Links to [cloudflare-zero-trust-demo-backend](https://github.com/macharpe/cloudflare-zero-trust-demo-backend) repository
  - Documents S3 bucket, DynamoDB table, and IAM policies requirements
  - Provides step-by-step setup instructions for new deployments
  - Updated Table of Contents with new section
  - Added `brew install azure-cli` to Azure CLI requirement

- **CHANGELOG.md**:
  - Added v2.9.2 release entry documenting the changes

## Testing

- [x] Documentation reviewed for accuracy
- [x] All links verified
- [x] Terraform fmt and validate pass

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated